### PR TITLE
Further fix to IP detection

### DIFF
--- a/Assets/OpenCog Assets/Scripts/OpenCog/Network/OCNetworkElement.cs
+++ b/Assets/OpenCog Assets/Scripts/OpenCog/Network/OCNetworkElement.cs
@@ -400,10 +400,10 @@ public class OCNetworkElement : OCSingletonMonoBehaviour<OCNetworkElement>
 			
 		foreach (NetworkInterface networkInterface in networkInterfaces)
 		{
-			var ipProperties = networkInterface.GetIPProperties();
-			var unicastAddresses = ipProperties.UnicastAddresses;
+			IPInterfaceProperties ipProperties = networkInterface.GetIPProperties();
+			UnicastIPAddressInformationCollection unicastAddresses = ipProperties.UnicastAddresses;
 				
-			foreach (var unicastAddress in unicastAddresses)
+			foreach (UnicastIPAddressInformation unicastAddress in unicastAddresses)
 			{
 				if (unicastAddress.DuplicateAddressDetectionState == DuplicateAddressDetectionState.Preferred &&
 					unicastAddress.AddressPreferredLifetime != System.UInt32.MaxValue)


### PR DESCRIPTION
On a computer with multiple network interface adapters listed when you type 'ipconfig', it was choosing the wrong address since it simply chose the first address. This adds some additional selection parameters recommended in this stackoverflow article to choose the active one.
